### PR TITLE
우편번호 5자리 필드일원화. 구주소 테마 사용시 버그패치

### DIFF
--- a/modules/member/lang.korean/pages/_mobile/join/step3.php
+++ b/modules/member/lang.korean/pages/_mobile/join/step3.php
@@ -192,9 +192,8 @@
 	<td>
 		<div id="addrbox">
 		<div>
-		<input type="number" name="zip_1" id="zip1" value="" maxlength="3" size="3" readonly="readonly" class="input" />-
-		<input type="number" name="zip_2" id="zip2" value="" maxlength="3" size="3" readonly="readonly" class="input" /> 
-		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=zip1&zip2=zip2&addr1=addr1&focusfield=addr2');" />
+		<input type="number" name="zip_1" id="zip1" value="" maxlength="6" size="6" readonly="readonly" class="input" /> 
+		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=zip1&addr1=addr1&focusfield=addr2');" />
 		</div>
 		<div><input type="text" name="addr1" id="addr1" value="" readonly="readonly" class="input lsize" /></div>
 		<div><input type="text" name="addr2" id="addr2" value="" class="input lsize" /></div>
@@ -385,9 +384,8 @@
 	<td class="key">사업장주소<span>*</span></td>
 	<td>
 		<div>
-		<input type="number" name="comp_zip_1" id="comp_zip1" value="" maxlength="3" size="3" readonly="readonly" class="input" />-
-		<input type="number" name="comp_zip_2" id="comp_zip2" value="" maxlength="3" size="3" readonly="readonly" class="input" /> 
-		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=comp_zip1&zip2=comp_zip2&addr1=comp_addr1&focusfield=comp_addr2');" />
+		<input type="number" name="comp_zip_1" id="comp_zip1" value="" maxlength="6" size="6" readonly="readonly" class="input" />
+		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=comp_zip1&addr1=comp_addr1&focusfield=comp_addr2');" />
 		</div>
 		<div><input type="text" name="comp_addr1" id="comp_addr1" value="" readonly="readonly" class="input lsize" /></div>
 		<div><input type="text" name="comp_addr2" id="comp_addr2" value="" class="input lsize" /></div>

--- a/modules/member/lang.korean/pages/_mobile/mypage/info.php
+++ b/modules/member/lang.korean/pages/_mobile/mypage/info.php
@@ -159,9 +159,8 @@
 	<td>
 		<div id="addrbox"<?php if($my['addr0']=='해외'):?> class="hide"<?php endif?>>
 		<div>
-		<input type="number" name="zip_1" id="zip1" value="<?php echo substr($my['zip'],0,3)?>" maxlength="3" size="3" readonly="readonly" class="input" />-
-		<input type="number" name="zip_2" id="zip2" value="<?php echo substr($my['zip'],3,3)?>" maxlength="3" size="3" readonly="readonly" class="input" /> 
-		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=zip1&zip2=zip2&addr1=addr1&focusfield=addr2');" />
+		<input type="number" name="zip_1" id="zip1" value="<?php echo $my['zip']?>" maxlength="6" size="6" readonly="readonly" class="input" />
+		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=zip1&addr1=addr1&focusfield=addr2');" />
 		</div>
 		<div><input type="text" name="addr1" id="addr1" value="<?php echo $my['addr1']?>" readonly="readonly" class="input addrx" /></div>
 		<div><input type="text" name="addr2" id="addr2" value="<?php echo $my['addr2']?>" class="input addrx" /></div>
@@ -363,9 +362,8 @@
 	<td class="key">사업장주소<span>*</span></td>
 	<td>
 		<div>
-		<input type="number" name="comp_zip_1" id="comp_zip1" value="<?php echo substr($myc['comp_zip'],0,3)?>" maxlength="3" size="3" readonly="readonly" class="input" />-
-		<input type="number" name="comp_zip_2" id="comp_zip2" value="<?php echo substr($myc['comp_zip'],3,3)?>" maxlength="3" size="3" readonly="readonly" class="input" /> 
-		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=comp_zip1&zip2=comp_zip2&addr1=comp_addr1&focusfield=comp_addr2');" />
+		<input type="number" name="comp_zip_1" id="comp_zip1" value="<?php echo $myc['comp_zip']?>" maxlength="6" size="6" readonly="readonly" class="input" /> 
+		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=comp_zip1&addr1=comp_addr1&focusfield=comp_addr2');" />
 		</div>
 		<div><input type="text" name="comp_addr1" id="comp_addr1" value="<?php echo $myc['comp_addr1']?>" readonly="readonly" class="input addrx" /></div>
 		<div><input type="text" name="comp_addr2" id="comp_addr2" value="<?php echo $myc['comp_addr2']?>" class="input addrx" /></div>

--- a/modules/member/lang.korean/pages/_pc/join/step3.php
+++ b/modules/member/lang.korean/pages/_pc/join/step3.php
@@ -190,9 +190,8 @@
 	<td>
 		<div id="addrbox">
 		<div>
-		<input type="text" name="zip_1" id="zip1" value="" maxlength="3" size="3" readonly="readonly" class="input" />-
-		<input type="text" name="zip_2" id="zip2" value="" maxlength="3" size="3" readonly="readonly" class="input" /> 
-		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=zip1&zip2=zip2&addr1=addr1&focusfield=addr2');" />
+		<input type="text" name="zip_1" id="zip1" value="" maxlength="6" size="6" readonly="readonly" class="input" /> 
+		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=zip1&addr1=addr1&focusfield=addr2');" />
 		</div>
 		<div><input type="text" name="addr1" id="addr1" value="" size="55" readonly="readonly" class="input" /></div>
 		<div><input type="text" name="addr2" id="addr2" value="" size="55" class="input" /></div>
@@ -374,9 +373,8 @@
 	<td class="key">사업장주소<span>*</span></td>
 	<td colspan="3">
 		<div>
-		<input type="text" name="comp_zip_1" id="comp_zip1" value="" maxlength="3" size="3" readonly="readonly" class="input" />-
-		<input type="text" name="comp_zip_2" id="comp_zip2" value="" maxlength="3" size="3" readonly="readonly" class="input" /> 
-		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=comp_zip1&zip2=comp_zip2&addr1=comp_addr1&focusfield=comp_addr2');" />
+		<input type="text" name="comp_zip_1" id="comp_zip1" value="" maxlength="6" size="6" readonly="readonly" class="input" />
+		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=comp_zip1&addr1=comp_addr1&focusfield=comp_addr2');" />
 		</div>
 		<div><input type="text" name="comp_addr1" id="comp_addr1" value="" size="55" readonly="readonly" class="input" /></div>
 		<div><input type="text" name="comp_addr2" id="comp_addr2" value="" size="55" class="input" /></div>

--- a/modules/member/lang.korean/pages/_pc/manager/info.php
+++ b/modules/member/lang.korean/pages/_pc/manager/info.php
@@ -158,9 +158,8 @@
 	<td>
 		<div id="addrbox"<?php if($M['addr0']=='해외'):?> class="hide"<?php endif?>>
 		<div>
-		<input type="text" name="zip_1" id="zip1" value="<?php echo substr($M['zip'],0,3)?>" maxlength="3" size="3" readonly="readonly" class="input" />-
-		<input type="text" name="zip_2" id="zip2" value="<?php echo substr($M['zip'],3,3)?>" maxlength="3" size="3" readonly="readonly" class="input" /> 
-		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=zip1&zip2=zip2&addr1=addr1&focusfield=addr2');" />
+		<input type="text" name="zip_1" id="zip1" value="<?php echo $M['zip']?>" maxlength="6" size="6" readonly="readonly" class="input" />
+		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=zip1&addr1=addr1&focusfield=addr2');" />
 		</div>
 		<div><input type="text" name="addr1" id="addr1" value="<?php echo $M['addr1']?>" size="55" readonly="readonly" class="input" /></div>
 		<div><input type="text" name="addr2" id="addr2" value="<?php echo $M['addr2']?>" size="55" class="input" /></div>
@@ -354,9 +353,8 @@
 	<td class="key">사업장주소<span>*</span></td>
 	<td colspan="3">
 		<div>
-		<input type="text" name="comp_zip_1" id="comp_zip1" value="<?php echo substr($myc['comp_zip'],0,3)?>" maxlength="3" size="3" readonly="readonly" class="input" />-
-		<input type="text" name="comp_zip_2" id="comp_zip2" value="<?php echo substr($myc['comp_zip'],3,3)?>" maxlength="3" size="3" readonly="readonly" class="input" /> 
-		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=comp_zip1&zip2=comp_zip2&addr1=comp_addr1&focusfield=comp_addr2');" />
+		<input type="text" name="comp_zip_1" id="comp_zip1" value="<?php echo $myc['comp_zip']?>" maxlength="6" size="6" readonly="readonly" class="input" />
+		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=comp_zip1&addr1=comp_addr1&focusfield=comp_addr2');" />
 		</div>
 		<div><input type="text" name="comp_addr1" id="comp_addr1" value="<?php echo $myc['comp_addr1']?>" size="55" readonly="readonly" class="input" /></div>
 		<div><input type="text" name="comp_addr2" id="comp_addr2" value="<?php echo $myc['comp_addr2']?>" size="55" class="input" /></div>

--- a/modules/member/lang.korean/pages/_pc/mypage/info.php
+++ b/modules/member/lang.korean/pages/_pc/mypage/info.php
@@ -157,9 +157,8 @@
 	<td>
 		<div id="addrbox"<?php if($my['addr0']=='해외'):?> class="hide"<?php endif?>>
 		<div>
-		<input type="text" name="zip_1" id="zip1" value="<?php echo substr($my['zip'],0,3)?>" maxlength="3" size="3" readonly="readonly" class="input" />-
-		<input type="text" name="zip_2" id="zip2" value="<?php echo substr($my['zip'],3,3)?>" maxlength="3" size="3" readonly="readonly" class="input" /> 
-		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=zip1&zip2=zip2&addr1=addr1&focusfield=addr2');" />
+		<input type="text" name="zip_1" id="zip1" value="<?php echo $my['zip']?>" maxlength="6" size="6" readonly="readonly" class="input" />
+		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=zip1&addr1=addr1&focusfield=addr2');" />
 		</div>
 		<div><input type="text" name="addr1" id="addr1" value="<?php echo $my['addr1']?>" size="55" readonly="readonly" class="input" /></div>
 		<div><input type="text" name="addr2" id="addr2" value="<?php echo $my['addr2']?>" size="55" class="input" /></div>
@@ -353,9 +352,8 @@
 	<td class="key">사업장주소<span>*</span></td>
 	<td colspan="3">
 		<div>
-		<input type="text" name="comp_zip_1" id="comp_zip1" value="<?php echo substr($myc['comp_zip'],0,3)?>" maxlength="3" size="3" readonly="readonly" class="input" />-
-		<input type="text" name="comp_zip_2" id="comp_zip2" value="<?php echo substr($myc['comp_zip'],3,3)?>" maxlength="3" size="3" readonly="readonly" class="input" /> 
-		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=comp_zip1&zip2=comp_zip2&addr1=comp_addr1&focusfield=comp_addr2');" />
+		<input type="text" name="comp_zip_1" id="comp_zip1" value="<?php echo $myc['comp_zip']?>" maxlength="6" size="6" readonly="readonly" class="input" />
+		<input type="button" value="우편번호" class="btngray btn" onclick="OpenWindow('<?php echo $g['s']?>/?r=<?php echo $r?>&m=zipsearch&zip1=comp_zip1&addr1=comp_addr1&focusfield=comp_addr2');" />
 		</div>
 		<div><input type="text" name="comp_addr1" id="comp_addr1" value="<?php echo $myc['comp_addr1']?>" size="55" readonly="readonly" class="input" /></div>
 		<div><input type="text" name="comp_addr2" id="comp_addr2" value="<?php echo $myc['comp_addr2']?>" size="55" class="input" /></div>

--- a/modules/zipsearch/theme/_mobile/default/front.php
+++ b/modules/zipsearch/theme/_mobile/default/front.php
@@ -95,8 +95,7 @@
 function zip_copy(zip1,zip2,addr)
 {
 	<?php if($focusfield):?>
-	opener.document.getElementById('<?php echo $zip1?>').value = zip1;
-	opener.document.getElementById('<?php echo $zip2?>').value = zip2;
+	opener.document.getElementById('<?php echo $zip1?>').value = zip1 + zip2;
 	opener.document.getElementById('<?php echo $addr1?>').value = addr;
 	opener.document.getElementById('<?php echo $focusfield?>').focus();
 	<?php endif?>

--- a/modules/zipsearch/theme/_pc/default/front.php
+++ b/modules/zipsearch/theme/_pc/default/front.php
@@ -15,7 +15,6 @@
 		<input type="hidden" name="m" value="<?php echo $m?>" />
 		<input type="hidden" name="action" value="search" />
 		<input type="hidden" name="zip1" value="<?php echo $zip1?>" />
-		<input type="hidden" name="zip2" value="<?php echo $zip2?>" />
 		<input type="hidden" name="addr1" value="<?php echo $addr1?>" />
 		<input type="hidden" name="focusfield" value="<?php echo $focusfield?>" />
 
@@ -95,8 +94,7 @@
 function zip_copy(zip1,zip2,addr)
 {
 	<?php if($focusfield):?>
-	opener.document.getElementById('<?php echo $zip1?>').value = zip1;
-	opener.document.getElementById('<?php echo $zip2?>').value = zip2;
+	opener.document.getElementById('<?php echo $zip1?>').value = zip1 + zip2;
 	opener.document.getElementById('<?php echo $addr1?>').value = addr;
 	opener.document.getElementById('<?php echo $focusfield?>').focus();
 	<?php endif?>


### PR DESCRIPTION
기존 패치에서 테마를 기존 테마(구주소)로 변경할경우
우편번호가 잘려서 들어가고, 주소1 공백이 생기는 현상을 패치하였습니다.
